### PR TITLE
Query orders by amount

### DIFF
--- a/service/models/order.py
+++ b/service/models/order.py
@@ -125,3 +125,28 @@ class Order(db.Model, PersistentBase):
             ) from error
 
         return self
+
+    @classmethod
+    def find_by_total_amount(
+        cls, min_amount=0.0, max_amount=0.0, sort_by="total_amount"
+    ):
+        """Returns all Items with the given product_id
+
+        Args:
+            product_id (integer): the product_id of the Items you want to match
+        """
+        logger.info(
+            "Processing min = %s and max = %s amount (sorted by %s) query for orders ...",
+            min_amount,
+            max_amount,
+            sort_by,
+        )
+        if sort_by.lower() == "total_amount":
+            sort_criterion = cls.total_amount.desc()
+        return (
+            cls.query.filter(
+                cls.total_amount >= min_amount, cls.total_amount <= max_amount
+            )
+            .order_by(sort_criterion)
+            .all()
+        )

--- a/service/routes.py
+++ b/service/routes.py
@@ -29,6 +29,8 @@ from service.models import Order, Item
 from service.models.order import OrderStatus
 from service.common import status  # HTTP Status Codes
 
+import math
+
 
 ######################################################################
 # GET INDEX
@@ -100,12 +102,36 @@ def list_orders():
     app.logger.info("Request for Order list")
     orders = []
 
-    orders = Order.all()
+    total_min = request.args.get("total-min")
+    total_max = request.args.get("total-max")
+    sort_by = request.args.get("sort_by")
+
+    if total_min is not None and total_max is not None and sort_by is not None:
+        orders = Order.find_by_total_amount(total_min, total_max, sort_by)
+    elif total_min is not None and total_max is None:
+        total_max = math.inf
+        orders = Order.find_by_total_amount(total_min, total_max, sort_by)
+    elif total_min is None and total_max is not None:
+        total_min = 0.0
+        orders = Order.find_by_total_amount(total_min, total_max, sort_by)
+    else:
+        orders = Order.all()
 
     # Return as an array of dictionaries
     results = [order.serialize() for order in orders]
 
     return jsonify(results), status.HTTP_200_OK
+
+
+# ######################################################################
+# # Query parameters validity check helper function
+# ######################################################################
+# def Convert_to_float(min, max):
+#     try:
+#         min = float(min)
+#         max = float(max)
+#     except ValueError:
+#         return None
 
 
 ######################################################################

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -234,6 +234,28 @@ class TestOrder(TestCase):
         order = OrderFactory()
         self.assertRaises(DataValidationError, order.update)
 
+    def test_find_by_total_amount(self):
+        """filter and sort orders by total amount"""
+
+        OrderFactory(total_amount=30.0).create()
+        OrderFactory(total_amount=20.0).create()
+        OrderFactory(total_amount=50.0).create()
+        OrderFactory(total_amount=10.0).create()
+        OrderFactory(total_amount=40.0).create()
+
+        orders = Order.find_by_total_amount(
+            min_amount=15.0, max_amount=40.0, sort_by="total_amount"
+        )
+        # Check length
+        self.assertEqual(len(orders), 3)
+        # Check range
+        self.assertGreaterEqual(orders[0].total_amount, 15)
+        self.assertLessEqual(orders[0].total_amount, 40)
+        # Check Order
+        self.assertEqual(orders[0].total_amount, 40)
+        self.assertEqual(orders[1].total_amount, 30)
+        self.assertEqual(orders[2].total_amount, 20)
+
 
 ######################################################################
 #  T E S T   E X C E P T I O N   H A N D L E R S

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -348,7 +348,7 @@ class TestOrderService(TestCase):
         sorting_criterion = "total_amount"
 
         # checking with only minimum value.
-        minimum = 60
+        minimum = 60.0
         resp = self.client.get(
             f"{BASE_URL}?total-min={minimum}&sort_by={sorting_criterion}"
         )
@@ -358,7 +358,7 @@ class TestOrderService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
         # checking with only maximum value.
-        maximum = 60
+        maximum = 60.0
         resp = self.client.get(
             f"{BASE_URL}?total-max={maximum}&sort_by={sorting_criterion}"
         )
@@ -368,8 +368,8 @@ class TestOrderService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
         #  checking with both minimum and maximum values.
-        minimum = 40
-        maximum = 60
+        minimum = 40.0
+        maximum = 60.0
         resp = self.client.get(
             f"{BASE_URL}?total-min={minimum}&total-max={maximum}&sort_by={sorting_criterion}"
         )
@@ -388,7 +388,7 @@ class TestOrderService(TestCase):
         sorting_criterion = "total_amount"
 
         minimum = "abc"
-        maximum = 60
+        maximum = 60.0
         resp = self.client.get(
             f"{BASE_URL}?total-min={minimum}&total-max={maximum}&sort_by={sorting_criterion}"
         )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -347,6 +347,20 @@ class TestOrderService(TestCase):
 
         sorting_criterion = "total_amount"
 
+        # Checking without any query.
+        resp = self.client.get(f"{BASE_URL}")
+        orders = resp.get_json()
+        self.assertIsInstance(orders, list)
+        self.assertEqual(len(orders), 5)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # Checking without any minimum or maximum value or sorting value.
+        resp = self.client.get(f"{BASE_URL}?sort_by={sorting_criterion}")
+        orders = resp.get_json()
+        self.assertIsInstance(orders, list)
+        self.assertEqual(len(orders), 5)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
         # checking with only minimum value.
         minimum = 60.0
         resp = self.client.get(


### PR DESCRIPTION
Solves Issue #42 .

- Added find_by_total_amount() class method in `models/orders.py` to filter orders based on a specified range for Total Amount.
- Returns the orders where `min<=total_amount<=max`
- Query string: `/orders?total-min={minimum}&total-max={maximum}&sort_by={sorting_criterion}`
- Sorting Criterion defaults to "total_amount".
- Orders are sorted in Descending order.
- Added test cases for successful filtering and bad requests.