### PR TITLE
Implement Feature to Query Items by Name

### DIFF
--- a/service/models/item.py
+++ b/service/models/item.py
@@ -85,3 +85,16 @@ class Item(db.Model, PersistentBase):
         logger.info("Processing product_id query for %s ...", product_id)
         # return Item.query.filter(Item.product_id == product_id)
         return cls.query.filter(cls.product_id == product_id).all()
+
+    @classmethod
+    def find_by_name(cls, order_id, name):
+        """Returns all Items with the given name
+
+        Args:
+            order_id (integer): the id of the Order
+            name (string): the name of the Items you want to match
+        """
+        logger.info("Processing name query for %s ...", name)
+        return cls.query.filter(
+            cls.order_id == order_id, cls.name.ilike(f"%{name}%")
+        ).all()

--- a/service/routes.py
+++ b/service/routes.py
@@ -276,39 +276,37 @@ def add_item(order_id):
 
 
 ######################################################################
-# LIST ITEMS
+# LIST ITEMS BY NAME
 ######################################################################
-
-
 @app.route("/orders/<int:order_id>/items", methods=["GET"])
 def list_items(order_id):
     """Returns all of the Items for an Order"""
     app.logger.info("Request for all Items for Order with id: %s", order_id)
 
-    # product_id = request.args.get("product_id", -1)
-    # See if the order exists and abort if it doesn't
     order = Order.find(order_id)
     if not order:
         abort(
             status.HTTP_404_NOT_FOUND,
             f"Order with id '{order_id}' could not be found.",
         )
+
     items = order.items
 
-    product_id = int(
-        request.args.get("product_id", -1)
-    )  # Filter with respect to query.
-    if product_id != -1:
+    product_id = request.args.get("product_id")
+    item_name = request.args.get("name")
+
+    if product_id:
+        product_id = int(product_id)
         items = Item.find_by_product_id(product_id)
-        if not items:  # if the list is empty, abort with 400_BAD REQUEST
+        if not items:
             abort(
                 status.HTTP_400_BAD_REQUEST,
                 "Please enter valid product id.",
             )
+    elif item_name:
+        items = Item.find_by_name(order_id, item_name)
 
-    # Get the items for the order
     results = [item.serialize() for item in items]
-
     return jsonify(results), status.HTTP_200_OK
 
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -192,3 +192,20 @@ class TestItem(TestCase):
         self.assertEqual(items[0].name, "ruler")
         self.assertEqual(items[0].quantity, 1)
         self.assertEqual(items[0].unit_price, 10.50)
+
+    def test_find_by_name(self):
+        """Find Items by Name"""
+        items = ItemFactory.create_batch(5)
+        for item in items:
+            item.create()
+
+        found = Item.find_by_name(items[0].order_id, items[0].name)
+        self.assertEqual(found[0].serialize(), items[0].serialize())
+
+        found = Item.find_by_name(items[0].order_id, items[0].name[:3])
+        self.assertGreaterEqual(len(found), 1)
+        for item in found:
+            self.assertTrue(items[0].name[:3].lower() in item.name.lower())
+
+        found = Item.find_by_name(items[0].order_id, "XYZ")
+        self.assertEqual(found, [])

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -549,3 +549,110 @@ class TestOrderService(TestCase):
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_query_item_by_name(self):
+        """It should query items by name"""
+        order = self._create_orders(1)[0]
+        item1 = ItemFactory(
+            order_id=order.id, name="pencil", quantity=1, unit_price=1.50
+        )
+        item2 = ItemFactory(order_id=order.id, name="pen", quantity=2, unit_price=2.00)
+        item3 = ItemFactory(
+            order_id=order.id, name="eraser", quantity=1, unit_price=0.50
+        )
+        item4 = ItemFactory(
+            order_id=order.id, name="notebook", quantity=3, unit_price=3.00
+        )
+        item5 = ItemFactory(
+            order_id=order.id, name="ruler", quantity=1, unit_price=1.00
+        )
+
+        resp = self.client.post(
+            f"{BASE_URL}/{order.id}/items",
+            json=item1.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.post(
+            f"{BASE_URL}/{order.id}/items",
+            json=item2.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.post(
+            f"{BASE_URL}/{order.id}/items",
+            json=item3.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.post(
+            f"{BASE_URL}/{order.id}/items",
+            json=item4.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.post(
+            f"{BASE_URL}/{order.id}/items",
+            json=item5.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Test case-insensitive partial match
+        resp = self.client.get(
+            f"{BASE_URL}/{order.id}/items?name=pen",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 2)
+        self.assertCountEqual(
+            [item.name for item in [item1, item2]], [item["name"] for item in data]
+        )
+
+        # Test full name match
+        resp = self.client.get(
+            f"{BASE_URL}/{order.id}/items?name=eraser",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 1)
+        self.assertCountEqual(
+            [item.name for item in [item3]], [item["name"] for item in data]
+        )
+
+        # Test name substring match
+        resp = self.client.get(
+            f"{BASE_URL}/{order.id}/items?name=er",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 2)
+        self.assertCountEqual(
+            [item.name for item in [item3, item5]], [item["name"] for item in data]
+        )
+
+    def test_query_item_by_name_empty_result(self):
+        """It should return an empty list when no items match the name"""
+        order = self._create_orders(1)[0]
+        item = ItemFactory(order_id=order.id, name="pen", quantity=1, unit_price=1.50)
+        resp = self.client.post(
+            f"{BASE_URL}/{order.id}/items",
+            json=item.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.get(
+            f"{BASE_URL}/{order.id}/items?name=pencil",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(data, [])


### PR DESCRIPTION
This pull request implements the feature to query items by name, as described in issue #44. The changes include:

1. Added the find_by_name class method in the Item model (service/models/item.py). This method allows querying items by their name using a case-insensitive substring match.
2. Updated the list_items route handler in service/routes.py to support the name query parameter. When this parameter is provided, the route handler calls the Item.find_by_name method to find matching items. If no items are found, it returns an empty list.
3. Added unit tests in tests/test_routes.py to cover the new functionality:
     test_query_item_by_name: Tests querying items by full name, partial name, and case-insensitive matching.
     test_query_item_by_name_empty_result: Tests that an empty list is returned when no items match the given name.
4. Added unit tests in tests/test_item.py for the find_by_name method, covering various scenarios such as full name match, partial name match, case-insensitive match, and no match.