### PR TITLE
Add GitHub Actions CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)
 [![codecov](https://codecov.io/gh/CSCI-GA-2820-SP24-003/orders/graph/badge.svg?token=7B9A593R95)](https://codecov.io/gh/CSCI-GA-2820-SP24-003/orders)
+![CI](https://github.com/CSCI-GA-2820-SP24-003/orders/actions/workflows/workflow.yml/badge.svg)
 
 ## Overview
 


### PR DESCRIPTION
Edited the README.md to have a continuous integration badge for Github Actions