### PR TITLE
Query orders by amount 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)
 [![codecov](https://codecov.io/gh/CSCI-GA-2820-SP24-003/orders/graph/badge.svg?token=7B9A593R95)](https://codecov.io/gh/CSCI-GA-2820-SP24-003/orders)
-![CI](https://github.com/CSCI-GA-2820-SP24-003/orders/actions/workflows/workflow.yml/badge.svg)
+[![CI](https://github.com/CSCI-GA-2820-SP24-003/orders/actions/workflows/workflow.yml/badge.svg)](https://github.com/CSCI-GA-2820-SP24-003/orders/actions)
 
 ## Overview
 

--- a/service/models/order.py
+++ b/service/models/order.py
@@ -131,6 +131,31 @@ class Order(db.Model, PersistentBase):
     ##################################################
 
     @classmethod
+    def find_by_total_amount(
+        cls, min_amount=0.0, max_amount=0.0, sort_by="total_amount"
+    ):
+        """Returns all Items with the given product_id
+
+        Args:
+            product_id (integer): the product_id of the Items you want to match
+        """
+        logger.info(
+            "Processing min = %s and max = %s amount (sorted by %s) query for orders ...",
+            min_amount,
+            max_amount,
+            sort_by,
+        )
+        if sort_by.lower() == "total_amount":
+            sort_criterion = cls.total_amount.desc()
+        return (
+            cls.query.filter(
+                cls.total_amount >= min_amount, cls.total_amount <= max_amount
+            )
+            .order_by(sort_criterion)
+            .all()
+        )
+
+    @classmethod
     def find_by_status(cls, status: OrderStatus) -> list:
         """Returns all Orders with a specific status
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -101,6 +101,8 @@ def list_orders():
     app.logger.info("Request for Order list")
     orders = []
 
+    orders = Order.all()
+
     total_min = request.args.get("total-min", default=0.0)
     print(type(total_min))
     total_max = request.args.get("total-max", default=math.inf)  # , type=float)
@@ -117,8 +119,8 @@ def list_orders():
                 status.HTTP_400_BAD_REQUEST,
                 "Please enter valid Minimum value. It should be a decimal value.",
             )
-    else:
-        orders = Order.all()
+    # else:
+    #     orders = Order.all()
 
     # Return as an array of dictionaries
     results = [order.serialize() for order in orders]

--- a/service/routes.py
+++ b/service/routes.py
@@ -19,6 +19,7 @@ Orders Service
 
 This service implements a REST API that allows you to manage Orders for a financial service.
 """
+import math
 
 from flask import jsonify
 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -280,3 +280,25 @@ class TestModelQueries(TestCaseBase):
         packing_orders = Order.find_by_status(OrderStatus.PACKING)
         self.assertEqual(len(packing_orders), 1)
         self.assertEqual(packing_orders[0].id, orders[1].id)
+
+    def test_find_by_total_amount(self):
+        """filter and sort orders by total amount"""
+
+        OrderFactory(total_amount=30.0).create()
+        OrderFactory(total_amount=20.0).create()
+        OrderFactory(total_amount=50.0).create()
+        OrderFactory(total_amount=10.0).create()
+        OrderFactory(total_amount=40.0).create()
+
+        orders = Order.find_by_total_amount(
+            min_amount=15.0, max_amount=40.0, sort_by="total_amount"
+        )
+        # Check length
+        self.assertEqual(len(orders), 3)
+        # Check range
+        self.assertGreaterEqual(orders[0].total_amount, 15)
+        self.assertLessEqual(orders[0].total_amount, 40)
+        # Check Order
+        self.assertEqual(orders[0].total_amount, 40)
+        self.assertEqual(orders[1].total_amount, 30)
+        self.assertEqual(orders[2].total_amount, 20)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -337,6 +337,77 @@ class TestOrderService(TestCase):
         response = self.client.get(f"{BASE_URL}/{test_order.id}")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_query_orders_by_total_amount(self):
+        """It should sort and filter orders in a particular range based on the total amount."""
+
+        for i in range(5):
+            total_amount = 30.0 + i * 10
+            order = OrderFactory(total_amount=total_amount)
+            order.create()
+
+        sorting_criterion = "total_amount"
+
+        # Checking without any query.
+        resp = self.client.get(f"{BASE_URL}")
+        orders = resp.get_json()
+        self.assertIsInstance(orders, list)
+        self.assertEqual(len(orders), 5)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # Checking without any minimum or maximum value or sorting value.
+        resp = self.client.get(f"{BASE_URL}?sort_by={sorting_criterion}")
+        orders = resp.get_json()
+        self.assertIsInstance(orders, list)
+        self.assertEqual(len(orders), 5)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # checking with only minimum value.
+        minimum = 60.0
+        resp = self.client.get(
+            f"{BASE_URL}?total-min={minimum}&sort_by={sorting_criterion}"
+        )
+        orders = resp.get_json()
+        self.assertIsInstance(orders, list)
+        self.assertEqual(len(orders), 2)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # checking with only maximum value.
+        maximum = 60.0
+        resp = self.client.get(
+            f"{BASE_URL}?total-max={maximum}&sort_by={sorting_criterion}"
+        )
+        orders = resp.get_json()
+        self.assertIsInstance(orders, list)
+        self.assertEqual(len(orders), 4)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        #  checking with both minimum and maximum values.
+        minimum = 40.0
+        maximum = 60.0
+        resp = self.client.get(
+            f"{BASE_URL}?total-min={minimum}&total-max={maximum}&sort_by={sorting_criterion}"
+        )
+        orders = resp.get_json()
+        self.assertIsInstance(orders, list)
+        self.assertEqual(len(orders), 3)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_query_orders_by_total_amount_bad_request(self):
+        """It should sort and filter orders in a particular range based on the total amount. (BAD REQUEST)."""
+        for i in range(5):
+            total_amount = 30.0 + i * 10
+            order = OrderFactory(total_amount=total_amount)
+            order.create()
+
+        sorting_criterion = "total_amount"
+
+        minimum = "abc"
+        maximum = 60.0
+        resp = self.client.get(
+            f"{BASE_URL}?total-min={minimum}&total-max={maximum}&sort_by={sorting_criterion}"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_bad_request(self):
         """It should not Create when sending the wrong data"""
         resp = self.client.post(BASE_URL, json={"name": "not enough data"})


### PR DESCRIPTION
Solves Issue #42 .

- Added f`ind_by_total_amount() `class method in `models/orders.py` to filter orders based on a specified range for Total Amount.
- Returns the orders where `min<=total_amount<=max`
- Query string: `/orders?total-min={minimum}&total-max={maximum}&sort_by={sorting_criterion}`
- Sorting Criterion defaults to "`total_amount`".
- Orders are sorted in Descending order.
- Added test cases for successful filtering and bad requests.
- Current local code coverage is 96.35%