### PR TITLE
Pack an order

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ create_orders     POST     /orders
 get_orders        GET      /orders/<order_id>
 update_orders     PUT      /orders/<order_id>
 delete_orders     DELETE   /orders/<order_id>
+cancel_orders     PUT      /orders/<order_id>/cancel
+pack_orders       PUT      /orders/<order_id>/packing
 
 list_items        GET      /orders/<int:order_id>/items
 create_items      POST     /orders/<order_id>/items

--- a/service/routes.py
+++ b/service/routes.py
@@ -227,6 +227,34 @@ def cancel_order(order_id):
 
 
 ######################################################################
+# PACK AN ORDER
+######################################################################
+@app.route("/orders/<int:order_id>/packing", methods=["PUT"])
+def pack_orders(order_id):
+    """Pack the Order that has not being shipped yet"""
+    app.logger.info("Request to pack order with id: %s", order_id)
+    order = Order.find(order_id)
+    if not order:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Orders with id {order_id} not found. Please enter a valid order id.",
+        )
+
+    # abort if invalid order status
+    # print(order.status)
+    if order.status not in (OrderStatus.STARTED, OrderStatus.PACKING):
+        abort(
+            status.HTTP_409_CONFLICT,
+            f"Orders that have been {order.status} cannot be set to PACKING ",
+        )
+
+    order.status = OrderStatus.PACKING
+    order.update()
+
+    return jsonify(order.serialize()), status.HTTP_200_OK
+
+
+######################################################################
 # GET A SINGLE ITEM IN AN ORDER
 ######################################################################
 @app.route("/orders/<int:order_id>/items/<int:item_id>", methods=["GET"])

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -344,6 +344,13 @@ class TestOrderService(TestCase):
         resp = self.client.post(BASE_URL, json=test_order.serialize())
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
+        # set status to started
+        new_order = resp.get_json()
+        new_order["status"] = "STARTED"
+        order_id = new_order["id"]
+        resp = self.client.put(f"{BASE_URL}/{order_id}", json=new_order)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
         # Pack a Started Order
         started_order = resp.get_json()
         order_id = started_order["id"]


### PR DESCRIPTION
solves issue #48 .

- added code for `/orders/{order_id}/packing`.
- added test cases to test bad requests, order not found and successful requests.
- updated README to reflect the new function
