### PR TITLE
Deliver an order

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ create_orders     POST     /orders
 get_orders        GET      /orders/<order_id>
 update_orders     PUT      /orders/<order_id>
 delete_orders     DELETE   /orders/<order_id>
-ship_orders       PUT      /orders/<order_id>/ship
-cancel_orders     PUT      /orders/<order_id>/cancel
 pack_orders       PUT      /orders/<order_id>/packing
+ship_orders       PUT      /orders/<order_id>/ship
+deliver_orders    PUT      /orders/<order_id>/deliver
+cancel_orders     PUT      /orders/<order_id>/cancel
 
 list_items        GET      /orders/<int:order_id>/items
 create_items      POST     /orders/<order_id>/items

--- a/service/routes.py
+++ b/service/routes.py
@@ -255,6 +255,34 @@ def pack_orders(order_id):
 
 
 ######################################################################
+# DELIVER AN ORDER
+######################################################################
+@app.route("/orders/<int:order_id>/deliver", methods=["PUT"])
+def deliver_orders(order_id):
+    """deliver the Order that has been shipped"""
+    app.logger.info("Request to deliver order with id: %s", order_id)
+    order = Order.find(order_id)
+    if not order:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Orders with id {order_id} not found. Please enter a valid order id.",
+        )
+
+    # abort if invalid order status
+    # print(order.status)
+    if order.status not in (OrderStatus.SHIPPING, OrderStatus.DELIVERED):
+        abort(
+            status.HTTP_409_CONFLICT,
+            f"Orders in {order.status} cannot be delivered.",
+        )
+
+    order.status = OrderStatus.DELIVERED
+    order.update()
+
+    return jsonify(order.serialize()), status.HTTP_200_OK
+
+
+######################################################################
 # GET A SINGLE ITEM IN AN ORDER
 ######################################################################
 @app.route("/orders/<int:order_id>/items/<int:item_id>", methods=["GET"])


### PR DESCRIPTION
solves Issues #46 

-Added code for deliver an order endpoint `PUT /orders/<int:order_id>/deliver`
-Added test cases to check successful cases, missing order ids, and bad requests.

> - succeeds with `200_OK` if successful
> - fails with `404_NOT_FOUND` if order id is invalid
> - fails with `409_CONFLICT` if current order status is `STARTED/PACKING/RETURNED/CANCELLED`


