### PR TITLE
Query Order by customer_id

### DIFF
--- a/service/models/order.py
+++ b/service/models/order.py
@@ -128,11 +128,11 @@ class Order(db.Model, PersistentBase):
         return self
 
     @classmethod
-    def find_by_customer_id(cls, customer_id):
+    def find_by_customer_id(cls, customer_ids):
         """Returns all Orders with the given customer id
 
         Args:
             customer_id (Integer): the customer_id of the Orders you want to match
         """
-        logger.info("Processing name query for %s ...", customer_id)
-        return cls.query.filter(cls.customer_id == customer_id).order_by(desc(Order.order_date))
+        logger.info("Processing name query for %s ...", customer_ids)
+        return cls.query.filter(cls.customer_id.in_(customer_ids)).order_by(desc(Order.order_date))

--- a/service/models/order.py
+++ b/service/models/order.py
@@ -21,6 +21,7 @@ Persistent Base class for database CRUD functions
 import logging
 from enum import Enum
 from datetime import date
+from sqlalchemy import desc
 from .persistent_base import db, PersistentBase, DataValidationError
 from .item import Item
 
@@ -125,3 +126,13 @@ class Order(db.Model, PersistentBase):
             ) from error
 
         return self
+
+    @classmethod
+    def find_by_customer_id(cls, customer_id):
+        """Returns all Orders with the given customer id
+
+        Args:
+            customer_id (Integer): the customer_id of the Orders you want to match
+        """
+        logger.info("Processing name query for %s ...", customer_id)
+        return cls.query.filter(cls.customer_id == customer_id).order_by(desc(Order.order_date))

--- a/service/routes.py
+++ b/service/routes.py
@@ -152,7 +152,7 @@ def list_orders():
 
         if not query_results:
             abort(
-                status.HTTP_400_BAD_REQUEST,
+                status.HTTP_404_NOT_FOUND,
                 f"{customer_id} is not a valid customer_id. Please enter an integer.",
             )
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -148,7 +148,7 @@ def list_orders():
         query = query.filter(Order.customer_id.in_(customer_id))
         # print(query)
         query_results = query.all()
-        print(f"----------------- {query_results}----------------- ")
+        # print(f"----------------- {query_results}----------------- ")
 
         if not query_results:
             abort(
@@ -162,7 +162,7 @@ def list_orders():
         query = query.order_by(Order.total_amount.desc())
 
     orders = query.all()
-    print(orders)
+    # print(orders)
     return jsonify([order.serialize() for order in orders]), status.HTTP_200_OK
 
 
@@ -467,7 +467,7 @@ def ship_orders(order_id):
             f"Order with id '{order_id}' could not be found.",
         )
 
-    print(order.status)
+    # print(order.status)
     if order.status not in [OrderStatus.CANCELLED, OrderStatus.DELIVERED]:
         order.status = OrderStatus.SHIPPING
         order.update()

--- a/service/routes.py
+++ b/service/routes.py
@@ -123,6 +123,20 @@ def list_orders():
                 "Please enter valid Minimum value. It should be a decimal value.",
             )
 
+    if customer_id is not None:
+        try:
+            customer_id = [int(customer_id)]
+        except ValueError:
+            try:
+                customer_id = customer_id.split(",")
+                customer_id = [int(c_id) for c_id in customer_id]
+                orders = Order.find_by_customer_id(customer_id)
+            except ValueError:
+                abort(
+                    status.HTTP_400_BAD_REQUEST,
+                    f"{customer_id} is not a valid customer_id. Please enter an integer."
+                )
+
     # Return as an array of dictionaries
     results = [order.serialize() for order in orders]
 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -24,9 +24,12 @@ from unittest import TestCase
 
 from unittest.mock import patch
 
+from datetime import date
+
 from wsgi import app
 from service.models import Order, Item, DataValidationError, db
 from tests.factories import OrderFactory, ItemFactory
+
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/postgres"
@@ -154,6 +157,52 @@ class TestOrder(TestCase):
         """It should not Deserialize an order with a TypeError"""
         order = Order()
         self.assertRaises(DataValidationError, order.deserialize, [])
+
+    def test_list_all_orders(self):
+        """It should List all Orders in the database"""
+        orders = Order.all()
+        self.assertEqual(orders, [])
+        for order in OrderFactory.create_batch(5):
+            order.create()
+        # Assert that there are 5 orders in the database
+        orders = Order.all()
+        self.assertEqual(len(orders), 5)
+
+    def test_find_by_customer_id(self):
+        """It should Find an Order by customer id, in sorted order"""
+        orders = Order.all()
+        self.assertEqual(orders, [])
+        counter = 0
+        for order in OrderFactory.create_batch(10):
+            order.create()
+
+            # Force the first 5 orders to have the same customer id, and the last 5 to have a different customer id
+            if counter < 5:
+                order.customer_id = 10
+                order.update()
+                self.assertEqual(order.customer_id, 10)
+            else:
+                order.customer_id = 20
+                order.update()
+            counter += 1
+
+        # Assert that there are 5 orders in the database
+        orders = Order.all()
+        self.assertEqual(len(orders), 10)
+
+        # Fetch it back by customer id
+        filtered_orders = Order.find_by_customer_id(10)
+
+        # Assert Number of Order with customer id 10 is 3
+        self.assertEqual(filtered_orders.count(), 5)
+
+        # Assert customer_ids of query are all 10, and are sorted by date.
+        test_date = date.today()
+        for order in filtered_orders:
+            self.assertEqual(order.customer_id, 10)
+            self.assertLessEqual(order.order_date, test_date)
+            test_date = order.order_date
+            self.assertEqual(order.order_date, test_date)
 
     def test_delete_a_order(self):
         """It should Delete a Order"""

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -173,33 +173,38 @@ class TestOrder(TestCase):
         orders = Order.all()
         self.assertEqual(orders, [])
         counter = 0
-        for order in OrderFactory.create_batch(10):
+        for order in OrderFactory.create_batch(15):
             order.create()
 
-            # Force the first 5 orders to have the same customer id, and the last 5 to have a different customer id
+            # Have 3 sets of 5 orders with different customer ids.
             if counter < 5:
                 order.customer_id = 10
                 order.update()
                 self.assertEqual(order.customer_id, 10)
-            else:
+            elif counter < 10:
                 order.customer_id = 20
                 order.update()
+                self.assertEqual(order.customer_id, 20)
+            else:
+                order.customer_id = 30
+                order.update()
+                self.assertEqual(order.customer_id, 30)
             counter += 1
 
-        # Assert that there are 5 orders in the database
+        # Assert that there are 15 orders in the database
         orders = Order.all()
-        self.assertEqual(len(orders), 10)
+        self.assertEqual(len(orders), 15)
 
         # Fetch it back by customer id
-        filtered_orders = Order.find_by_customer_id(10)
+        filtered_orders = Order.find_by_customer_id([10, 30])
 
-        # Assert Number of Order with customer id 10 is 3
-        self.assertEqual(filtered_orders.count(), 5)
+        # Assert Number of Order with customer id 10 or 30 is 10
+        self.assertEqual(filtered_orders.count(), 10)
 
-        # Assert customer_ids of query are all 10, and are sorted by date.
+        # Assert customer_ids of query are all 10 or 30, and are sorted by date.
         test_date = date.today()
         for order in filtered_orders:
-            self.assertEqual(order.customer_id, 10)
+            self.assertIn(order.customer_id, [10, 30])
             self.assertLessEqual(order.order_date, test_date)
             test_date = order.order_date
             self.assertEqual(order.order_date, test_date)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -201,7 +201,7 @@ class TestOrderService(TestCase):
         resp = self.client.get(
             f"{BASE_URL}?customer-id={random_cid}&sort_by={sorting_criterion}"
         )
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
         # Initiate Query with invalid c_id
         random_cid = "abc"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -21,7 +21,7 @@ BASE_URL = "/orders"
 ######################################################################
 #  T E S T   C A S E S
 ######################################################################
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods, too-many-lines
 class TestOrderService(TestCase):
     """REST API Server Tests"""
 


### PR DESCRIPTION
Solves issue #37 

- REST URI : `/orders?customer-id="{customer-id}"&sort_by="order-date"`
- added `find_by_customer_id()` method in orders class
- updated `PUT /orders` endpoint to handle queries to filter by customer_id.
- Added test cases to check with single customer_id, multiple customer_ids, invalid ids.

> - Succeeds with 200_OK if orders successfully filtered.
> - Fails with 400_BAD_REQUEST if customer)id is invalid (such as customer_id = "abc"). 
> - Fails with 404_NOT_FOUND if customer id is a valid integer but not found in records.