### PR TITLE
Querying list orders and Items feature for BDD testing

### DIFF
--- a/features/orders.feature
+++ b/features/orders.feature
@@ -5,9 +5,9 @@ Feature: The Order service back-end
 
 Background:
     Given the following orders
-        | customer_id | order_date | status   | shipping_address | total_amount | payment_method | shipping_cost | expected_date | order_notes |
-        | 123         | 2022-06-16 | STARTED  | fake address      | 1            | CREDIT         | 10            | 2022-06-20    | Some notes |
-        | 456         | 2022-07-01 | SHIPPING | real address      | 100.50       | DEBIT          | 5.99          | 2022-07-05    | Special notes |
+        | customer_id | order_date | status   | shipping_address | total_amount | payment_method | shipping_cost | expected_date | order_notes   |
+        | 123         | 2022-06-16 | STARTED  | fake address     | 1300         | CREDIT         | 10            | 2022-06-20    | Some notes    |
+        | 456         | 2022-07-01 | SHIPPING | real address     | 100.50       | DEBIT          | 5.99          | 2022-07-05    | Special notes |
     Given the following items:
         |product_id    | name       | quantity           | unit_price   | total_price     |description      |
         |25            | Phone      | 2                  | 1000         | 2000            |it's a phone     |
@@ -68,6 +68,7 @@ Scenario: Create an Item
     And I should see the calculated "Total Price" in the "Total Price" field
     And I should see "None" in the "Description" field
 
+
 Scenario: List all Orders
     When I visit the "Home Page"
     And I press the "Clear" button
@@ -76,6 +77,7 @@ Scenario: List all Orders
     And I should see "SHIPPING" in the "Order" results
     And I should see "STARTED" in the "Order" results
     And I should not see "PACKING" in the "Order" results
+
 
 Scenario: List Items
     When I visit the "Home Page"
@@ -91,6 +93,73 @@ Scenario: List Items
     Then I should see the message "Success"
     And I should see "Phone" in the "Item" results
     And I should see "Laptop" in the "Item" results
+
+
+Scenario: Query Orders
+    When I visit the "Home Page"
+    And I press the "Clear" button
+    And I press the "Search" button
+    Then I should see the message "Success"
+    When I press the "Clear Item" button
+    Then the "Item ID" field should be empty
+    When I copy the "Order ID" field
+    And I press the "Clear" button
+    And I paste the "Item Order ID" field
+    And I press the "Search Item" button
+    Then I should see the message "Success"
+    And I should see "SHIPPING" in the "Order" results
+    And I should not see "STARTED" in the "Order" results
+    When I press the "Clear" button
+    Then the "Status" field should be empty
+    WHEN I set the "Customer ID" to "456"
+    And I press the "Search" button
+    Then I should see the message "Success"
+    And I should see "456" in the "Order" results
+    And I should not see "123" in the "Order" results
+    When I press the "Clear" button
+    Then the "Customer ID" field should be empty
+    WHEN I set the "Total Amount" to "1300"
+    And I press the "Search" button
+    Then I should see the message "Success"
+    And I should see "1300" in the "Order" results
+    And I should not see "100.50" in the "Order" results
+    When I press the "Clear" button
+    Then the "Total Amount" field should be empty
+    WHEN I set the "Order Date" to "06-16-2022"
+    And I press the "Search" button
+    Then I should see the message "Success"
+    And I should see "2022-06-16" in the "Order" results
+    And I should not see "2022-07-01" in the "Order" results
+    When I press the "Clear" button
+    Then the "Order Date" field should be empty
+
+
+Scenario: Query Items
+    When I visit the "Home Page"
+    And I press the "Clear" button
+    And I press the "Search" button
+    Then I should see the message "Success"
+    WHEN I set the "Status" to "SHIPPING"
+    And I press the "Search" button
+    Then I should see the message "Success"
+    And I save the "Order Id" field as "order_id"
+    And I set the "Item Order ID" to "{order_id}"
+    And I set the "Product ID" to "25"
+    And I press the "Search Item" button
+    Then I should see the message "Success"
+    And I should see "Phone" in the "Item" results
+    And I should not see "Laptop" in the "Item" results
+    When I press the "Clear Item" button
+    Then the "Product ID" field should be empty
+    When I set the "Item Order ID" to "{order_id}"
+    And I set the "name" to "lapt"
+    And I press the "Search Item" button
+    Then I should see the message "Success"
+    And I should see "Laptop" in the "Item" results
+    And I should not see "Phone" in the "Item" results
+    When I press the "Clear Item" button
+    Then the "name" field should be empty
+
 
 Scenario: Read an Order
     When I visit the "Home Page"

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -100,12 +100,9 @@ Scenario: Query Orders
     And I press the "Clear" button
     And I press the "Search" button
     Then I should see the message "Success"
-    When I press the "Clear Item" button
-    Then the "Item ID" field should be empty
-    When I copy the "Order ID" field
-    And I press the "Clear" button
-    And I paste the "Item Order ID" field
-    And I press the "Search Item" button
+    When I press the "Clear" button
+    And I set the "Status" to "Shipping"
+    And I press the "Search" button
     Then I should see the message "Success"
     And I should see "SHIPPING" in the "Order" results
     And I should not see "STARTED" in the "Order" results
@@ -125,11 +122,10 @@ Scenario: Query Orders
     And I should not see "100.50" in the "Order" results
     When I press the "Clear" button
     Then the "Total Amount" field should be empty
-    WHEN I set the "Order Date" to "06-16-2022"
+    WHEN I set the "Order Date" to "01-07-2022"
     And I press the "Search" button
     Then I should see the message "Success"
-    And I should see "2022-06-16" in the "Order" results
-    And I should not see "2022-07-01" in the "Order" results
+    And I should see "2022-07-01" in the "Order" results
     When I press the "Clear" button
     Then the "Order Date" field should be empty
 
@@ -139,11 +135,11 @@ Scenario: Query Items
     And I press the "Clear" button
     And I press the "Search" button
     Then I should see the message "Success"
-    WHEN I set the "Status" to "SHIPPING"
+    WHEN I set the "Status" to "Shipping"
     And I press the "Search" button
     Then I should see the message "Success"
-    And I save the "Order Id" field as "order_id"
-    And I set the "Item Order ID" to "{order_id}"
+    Then I save the "Order Id" field as "order_id"
+    When I set the "Item Order ID" to "{order_id}"
     And I set the "Product ID" to "25"
     And I press the "Search Item" button
     Then I should see the message "Success"

--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -144,7 +144,7 @@ def step_impl(context, element_name):
 @then('I should see "{name}" in the "{table_name}" results')
 def step_impl(context, name, table_name):
     table_id = "search_" + table_name.lower() + "_results"
-    print(table_id)
+    # print(table_id)
     found = WebDriverWait(context.driver, context.wait_seconds).until(
         expected_conditions.text_to_be_present_in_element(
             (By.ID, table_id), name
@@ -156,8 +156,9 @@ def step_impl(context, name, table_name):
 @then('I should not see "{name}" in the "{table_name}" results')
 def step_impl(context, name, table_name):
     table_id = "search_" + table_name.lower() + "_results"
-    print(table_id)
+    # print(table_id)
     element = context.driver.find_element(By.ID, table_id)
+    # print(f"element = {element}")
     assert name not in element.text
 
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -109,7 +109,7 @@ def list_orders():
 
     # try:
     query = Order.query
-    
+
     if order_status:
         query = query.filter(Order.status == order_status)
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -96,15 +96,22 @@ def list_orders():
     """Returns all Orders within a date range and total amount range if specified, sorted by order date or total amount."""
     app.logger.info("Request for Order list")
 
+    app.logger.info(f"request.url : {request.url}")
+
     start_date_str = request.args.get("order-start")
     end_date_str = request.args.get("order-end")
     total_min = request.args.get("total-min", default=0.0)
     total_max = request.args.get("total-max", default=math.inf)
     customer_id = request.args.get("customer-id")
+    order_status = request.args.get("status")
+    app.logger.info(status)
     sort_by = request.args.get("sort_by", default="order_date")
 
     # try:
     query = Order.query
+    
+    if order_status:
+        query = query.filter(Order.status == order_status)
 
     if start_date_str:
         start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
@@ -155,7 +162,7 @@ def list_orders():
         query = query.order_by(Order.total_amount.desc())
 
     orders = query.all()
-    # print(orders)
+    app.logger.info(orders)
     return jsonify([order.serialize() for order in orders]), status.HTTP_200_OK
 
 

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -240,13 +240,13 @@ $(function () {
         let queryString = ""
 
         if (customer_id) {
-            queryString += 'customer_id=' + customer_id
+            queryString += 'customer-id=' + customer_id
         }
         if (order_date) {
             if (queryString.length > 0) {
-                queryString += '&order_date=' + order_date
+                queryString += '&order-start=' + order_date
             } else {
-                queryString += 'order_date=' + order_date
+                queryString += 'order-start=' + order_date
             }
         }
         if (status) {
@@ -258,9 +258,9 @@ $(function () {
         }
         if (total_amount) {
             if (queryString.length > 0) {
-                queryString += '&total_amount=' + total_amount
+                queryString += '&total-min=' + total_amount
             } else {
-                queryString += 'total_amount=' + total_amount
+                queryString += 'total-min=' + total_amount
             }
         }
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -780,6 +780,21 @@ class TestOrderService(TestCase):
 
         orders = response.get_json()
         self.assertIsInstance(orders, list)
+    
+    def test_query_order_list_by_status(self):
+        """It should Query Orders by Status"""
+        orders = self._create_orders(10)
+        test_status = orders[0].status
+        status_orders = [order for order in orders if order.status == test_status]
+        response = self.client.get(
+            BASE_URL, query_string=f"status={(test_status.name)}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(len(data), len(status_orders))
+        # check the data just to be sure
+        for order in data:
+            self.assertEqual(order["status"], test_status.name)
 
     ######################################################################
     #  I T E M   T E S T   C A S E S

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -780,7 +780,7 @@ class TestOrderService(TestCase):
 
         orders = response.get_json()
         self.assertIsInstance(orders, list)
-    
+
     def test_query_order_list_by_status(self):
         """It should Query Orders by Status"""
         orders = self._create_orders(10)


### PR DESCRIPTION
Addresses issue #71 

- fixed typos in query string structure in `rest_api.js`
- Added missing code to query orders by status in `LIST (GET /orders)` endpoint in `service/routes.py`
- Added missing test cases to test query orders by status in` tests/test_routes.py`

> - increased test coverage to 96.71%

- Added test scenarios for BDD Testing for 

> - Querying orders by `customer_id`
> - Querying orders by `total_amount`
> - Querying orders by `status`
> - Querying orders by `order-date`
> - Querying items by `name` as a substring
> - Querying items by `product_id`


