### PR TITLE
Add swagger annotions and fix the apidoc

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -89,7 +89,7 @@ order_create_model = api.model(
         ),
         # pylint: disable=protected-access
         "status": fields.String(
-            enum=OrderStatus, description="The status of the Order"
+            enum=[e.value for e in OrderStatus], description="The status of the Order"
         ),
         "shipping_address": fields.String(
             required=True, description="The place where the Order is delivered to"

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -272,6 +272,6 @@
 
   <!-- YOUR REST API -->
   <script type="text/javascript" src="static/js/rest_api.js"></script>
-
+  <p>API Documentation is <a href='/apidocs'>here</a></p>
   </body>
 </html>


### PR DESCRIPTION
Changes made:

Updated the routes.py file:

Modified the status field in the order_create_model to use enum=[e.value for e in OrderStatus] instead of enum=OrderStatus. This change ensures that the Swagger documentation correctly displays the possible values for the status field.


Updated the index.html file:

Added a link to the API documentation at /apidocs. This allows users to easily access the Swagger UI and explore the documented REST API.